### PR TITLE
Cross build with 2.12.x 2.13.x 0.6.x 1.x.x latest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,21 +4,36 @@ organization := "me.shadaj"
 
 name := "slinky-styled-components"
 
-scalaVersion := "2.12.8"
+val scala212 = "2.12.13"
+val scala213 = "2.13.4"
 
-libraryDependencies += "me.shadaj" %%% "slinky-web" % "0.6.0"
+scalaVersion := scala213
+crossScalaVersions := Seq(scala212, scala213)
 
-libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.3" % Test
+libraryDependencies += "me.shadaj" %%% "slinky-web" % "0.6.5"
+
+libraryDependencies += "org.scalatest" %%% "scalatest" % "3.1.4" % Test
 
 npmDependencies in Test += "react" -> "16.8.4"
 npmDependencies in Test += "react-dom" -> "16.8.4"
 npmDependencies in Test += "styled-components" -> "4.2.0"
-jsDependencies += RuntimeDOM % Test
 
-scalacOptions += "-P:scalajs:sjsDefinedByDefault"
-scalacOptions += "-Ywarn-unused-import"
+requireJsDomEnv in Test := true
 
-addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full)
+scalacOptions ++= {
+  if (scalaJSVersion.startsWith("0.6.")) Seq("-P:scalajs:sjsDefinedByDefault")
+  else Nil
+}
+
+scalacOptions ++= {
+  if (scalaVersion.value == scala213) Seq("-Ymacro-annotations")
+  else Nil
+}
+
+libraryDependencies ++= {
+  if (scalaVersion.value == scala213) Seq.empty
+  else Seq(compilerPlugin(("org.scalamacros" % "paradise" % "2.1.1").cross(CrossVersion.full)))
+}
 
 // Source Generation -----------------------------
 // from styled-components/src/utils/domElements.js

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.4
+sbt.version=1.4.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,17 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
+val scalaJSVersion =
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.33")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.13.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+
+{
+  if (scalaJSVersion.startsWith("0.6.")) addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler-sjs06" % "0.19.0")
+  else addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.20.0")
+}
+
+libraryDependencies ++= {
+  if (scalaJSVersion.startsWith("0.6.")) Nil
+  else Seq("org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.1.0")
+}
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
 


### PR DESCRIPTION
Introduced `SCALAJS_VERSION` env var as in `slinky` build (tested with `0.6.33`, `1.4.0`) + conditionals for cross building
Bumped sbt to `1.4.4` (warnings in publish.sbt)
Bumped `slinky`, `scalatest` to the highest possible version (compilation errors for `0.6.6`, `3.2.x`)

Please let me know if there's anything more I can help with.