### PR TITLE
Fix props function interpolation

### DIFF
--- a/src/main/scala/slinky/styledcomponents/InterpolationPart.scala
+++ b/src/main/scala/slinky/styledcomponents/InterpolationPart.scala
@@ -1,17 +1,22 @@
 package slinky.styledcomponents
 
+import slinky.readwrite.Reader
+
 import scala.scalajs.js
 import js.JSConverters._
-
 import scala.language.implicitConversions
 
 trait InterpolationPart[-P] extends js.Object
 trait KeyframesInterpolationPart[-P] extends InterpolationPart[P]
 
 object InterpolationPart {
-  implicit def fromPropsFunction[P, O](fn: P => O)(implicit ev: O => InterpolationPart[P]): InterpolationPart[P] = {
+  implicit def fromPropsFunction[P, O](fn: P => O)(implicit ev: O => InterpolationPart[P], reader: Reader[P]): InterpolationPart[P] = {
     (((o: js.Any) => {
-      fn(o.asInstanceOf[js.Dynamic].__.asInstanceOf[P])
+      val props = if (o.asInstanceOf[js.Object].hasOwnProperty("__"))
+        o.asInstanceOf[js.Dynamic].__.asInstanceOf[P]
+      else
+        reader.read(o.asInstanceOf[js.Object])
+      fn(props)
     }): js.Function1[js.Any, js.Any]).asInstanceOf[InterpolationPart[P]]
   }
 


### PR DESCRIPTION
Add and use Reader when .__ is absent.

Closes #6 